### PR TITLE
Support meta blocks and shorthand defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Place your default templates in `configs/defaults/`. Each file may define **mult
 ```toml
 # defaults/app_defaults.toml
 
+[__meta__]
+name = "Config - QuickBooks Invoice Saver"
+module_version = "0.1.0"
+
 [QuickBooks.Invoices.Saver]
 SHOW_TOASTS = true
 WINDOW_LOAD_DELAY  = { defaultValue = 0.5,  type = "float", min = 0.0 }
@@ -144,6 +148,7 @@ ENABLE_LOGS = { defaultValue = true,   type = "bool" }
 
   * A primitive default: `KEY = 123` (shorthand for a setting with only `defaultValue`).
   * A full schema object: specifying `type`, optional `min`/`max`, `allowedValues`, and `validator`.
+* An optional `[__meta__]` table may be present and is ignored by the library.
 
 ## Supported Types
 

--- a/example_project/configs/defaults/example_defaults.toml
+++ b/example_project/configs/defaults/example_defaults.toml
@@ -1,3 +1,8 @@
+
+[__meta__]
+name = "Demo defaults"
+module_version = "0.1.0"
+
 ["DemoApp.General"]
 LOG_LEVEL = { defaultValue = "INFO", type = "str", allowedValues = ["DEBUG","INFO","WARNING","ERROR"] }
 RETRY_COUNT = { defaultValue = 3, type = "int", min = 0 }
@@ -6,3 +11,4 @@ REFRESH_TIMES = { defaultValue = [08:00:00, 12:00:00], type = "list" }
 
 ["DemoApp.Features"]
 ENABLE_FEATURE_X = { defaultValue = true, type = "bool" }
+SHOW_TOASTS = true


### PR DESCRIPTION
## Summary
- allow shorthand defaults by inferring types
- ignore `[__meta__]` tables in defaults
- document meta table and update example project

## Testing
- `PYTHONPATH=src python example_project/run_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_68437db219888320887a72fce60925ec