### PR TITLE
Add verbose type hints

### DIFF
--- a/example_project/run_demo.py
+++ b/example_project/run_demo.py
@@ -1,8 +1,14 @@
+"""Demonstration script for :mod:`toml_init`."""
+
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any, Dict
 from toml_init import ConfigManager
 
 
 def main() -> None:
+    """Run the demo project."""
     base_path = Path(__file__).parent / "configs"
     defaults_path = base_path / "defaults"
     cm = ConfigManager(
@@ -12,8 +18,8 @@ def main() -> None:
     )
     cm.initialize(dry_run=False)
 
-    general = cm.get_block("DemoApp.General")
-    features = cm.get_block("DemoApp.Features")
+    general: Dict[str, Any] = cm.get_block("DemoApp.General")
+    features: Dict[str, Any] = cm.get_block("DemoApp.Features")
 
     print("General settings:", general)
     print("Feature flags:", features)

--- a/src/toml_init/__init__.py
+++ b/src/toml_init/__init__.py
@@ -1,4 +1,8 @@
-# src\toml_init\__init__.py
+"""Public API for the :mod:`toml_init` package."""
+
+from __future__ import annotations
+
+from typing import List
 
 from toml_init.manager import ConfigManager, main
 from toml_init.exceptions import (
@@ -10,7 +14,7 @@ from toml_init.exceptions import (
 )
 from toml_init.validators import register_validator, Validator, CUSTOM_VALIDATORS
 
-__all__ = [
+__all__: List[str] = [
     "ConfigManager",
     "main",
     "TomlInitError",

--- a/src/toml_init/__main__.py
+++ b/src/toml_init/__main__.py
@@ -1,6 +1,14 @@
-# src\toml_init\__main__.py
+"""Entry point for the ``toml-init`` console script."""
+
+from __future__ import annotations
+
 import sys
+from typing import NoReturn
 from toml_init.manager import main
 
-if __name__ == "__main__":
-    sys.exit(main())
+
+if __name__ == "__main__":  # pragma: no cover - direct CLI execution
+    def _entry() -> NoReturn:
+        sys.exit(main())
+
+    _entry()

--- a/src/toml_init/exceptions.py
+++ b/src/toml_init/exceptions.py
@@ -1,4 +1,5 @@
-# src\toml_init\exceptions.py
+"""Exception hierarchy for :mod:`toml_init`."""
+
 
 class TomlInitError(Exception):
     """Base class for all toml-init exceptions."""

--- a/src/toml_init/utils.py
+++ b/src/toml_init/utils.py
@@ -1,0 +1,1 @@
+"""Miscellaneous helper functions (currently empty)."""

--- a/src/toml_init/validators.py
+++ b/src/toml_init/validators.py
@@ -1,5 +1,9 @@
-# src\toml_init\validators.py
+"""Utilities for registering and running custom validators."""
+
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any, Dict
 from toml_init.exceptions import InvalidConfigValueError, InvalidDefaultSchemaError
 
 class Validator(ABC):
@@ -11,18 +15,18 @@ class Validator(ABC):
     """
 
     @abstractmethod
-    def validate(self, value):
+    def validate(self, value: Any) -> Any:
         """Validate (and optionally coerce) `value`."""
         ...
 
-    def __call__(self, value):
+    def __call__(self, value: Any) -> Any:
         return self.validate(value)
 
 # Registry for custom validators
-CUSTOM_VALIDATORS: dict[str, Validator] = {}
+CUSTOM_VALIDATORS: Dict[str, Validator] = {}
 
 
-def register_validator(name: str, validator: Validator):
+def register_validator(name: str, validator: Validator) -> None:
     """
     Register a Validator instance under the given name.
     """


### PR DESCRIPTION
## Summary
- enrich modules with optional typing imports and annotations
- expose typed `__all__` in package init
- annotate validator utilities and demo script
- improve CLI entry point typing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=src python src/toml_init/__main__.py --dry-run --verbose -b example_project/configs`


------
https://chatgpt.com/codex/tasks/task_e_684380ffb23c83208fa1cf669e8d1468